### PR TITLE
GPIB-417

### DIFF
--- a/src/components/VerificationTracker/AddAddress.js
+++ b/src/components/VerificationTracker/AddAddress.js
@@ -8,8 +8,8 @@ import Loader from "components/Loader";
 import { Button, Spinner, Alert } from "react-bootstrap";
 import Card from "components/Card";
 
-const AddAddress = () => {
-  const { user } = useContext(AuthContext);
+const AddAddress = ({ userEnterprise }) => {
+  const { user, setVerified, setSkipKYC } = useContext(AuthContext);
   const { data: userHDAddress, error: fetchHDAddressError } = useSWR(
     `/user/${user.id}/address`
   );
@@ -35,6 +35,10 @@ const AddAddress = () => {
       await gpib.secure.post("/user/hdaddress");
       await mutate(`/user/${user.id}/address`);
       setIsSubmitting(false);
+      if (!userEnterprise?.name) {
+        setSkipKYC(true);
+        setVerified(true);
+      }
     } catch (error) {
       console.error(error);
     } finally {
@@ -83,8 +87,10 @@ const AddAddress = () => {
                 />
                 Submitting
               </>
-            ) : (
+            ) : userEnterprise?.name ? (
               "Generate HD Address"
+            ) : (
+              "Generate HD Address and Skip KYC"
             )}
           </Button>
         </div>

--- a/src/components/VerificationTracker/VerificationTracker.js
+++ b/src/components/VerificationTracker/VerificationTracker.js
@@ -41,16 +41,16 @@ const VerificationTracker = ({
       panel: <VerifyMobile />
     },
     {
-      label: "Add BTC address",
-      icon: "logo-bitcoin",
-      isCompleted: userAddress && userAddress.length > 0,
-      panel: <AddAddress />
-    },
-    {
       label: "Add Payroll Information",
       icon: "cash-outline",
       isCompleted: depositHints?.depositAmount !== undefined,
       panel: <AddPayroll userEnterprise={userEnterprise} />
+    },
+    {
+      label: "Add BTC address",
+      icon: "logo-bitcoin",
+      isCompleted: userAddress && userAddress.length > 0,
+      panel: <AddAddress userEnterprise={userEnterprise} />
     }
   ];
   if (!employerName) {

--- a/src/components/VerificationTracker/VerifyID.js
+++ b/src/components/VerificationTracker/VerifyID.js
@@ -106,15 +106,13 @@ const VerifyID = () => {
           />
         )}
       </div>
-      {userAddress &&
-        userAddress[0].label.toLowerCase() ===
-          "GPIB Custodial Wallet".toLowerCase() && (
-          <div className="mt-2 d-flex flex-row-reverse">
-            <Button variant="primary" block onClick={handleSkipKYC}>
-              Skip KYC
-            </Button>
-          </div>
-        )}
+      {userAddress && userAddress[0].isCustodial && (
+        <div className="mt-2 d-flex flex-row-reverse">
+          <Button variant="primary" block onClick={handleSkipKYC}>
+            Skip KYC
+          </Button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/VerificationTracker/VerifyID.js
+++ b/src/components/VerificationTracker/VerifyID.js
@@ -34,10 +34,11 @@ const statusAlerts = {
 };
 
 const VerifyID = () => {
-  const { user } = useContext(AuthContext);
+  const { user, setVerified, setSkipKYC } = useContext(AuthContext);
   const { data: userDetails, error: fetchDetailsError } = useSWR(
     user && `/user/${user.id}`
   );
+  const { data: userAddress } = useSWR(`/user/${user.id}/address`);
   const idVerificationStatus = userDetails?.idVerificationStatus;
   const mobile = userDetails?.mobileNumber;
   const isStarted = idVerificationStatus >= statuses.STARTED;
@@ -71,6 +72,10 @@ const VerifyID = () => {
     setResend(true);
   };
 
+  const handleSkipKYC = () => {
+    setSkipKYC(true);
+    setVerified(true);
+  };
   return (
     <div>
       <p>
@@ -101,6 +106,15 @@ const VerifyID = () => {
           />
         )}
       </div>
+      {userAddress &&
+        userAddress[0].label.toLowerCase() ===
+          "GPIB Custodial Wallet".toLowerCase() && (
+          <div className="mt-2 d-flex flex-row-reverse">
+            <Button variant="primary" block onClick={handleSkipKYC}>
+              Skip KYC
+            </Button>
+          </div>
+        )}
     </div>
   );
 };

--- a/src/components/VerificationTracker/VerifyMobile.js
+++ b/src/components/VerificationTracker/VerifyMobile.js
@@ -9,9 +9,8 @@ import { AuthContext } from "components/auth/Auth";
 
 const VerifyEmail = () => {
   const [hasSent, setSent] = useState(false);
-  const { user, setVerified } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
   const [message, setMessage] = useState();
-
   const sendSMS = async (values, actions) => {
     try {
       await gpib.secure.get(`/user/verifymobile?mobile=${values.mobile}`);
@@ -74,39 +73,29 @@ const VerifyEmail = () => {
     );
   };
 
-  const skipKYC = () => {
-    setVerified(true);
-  };
   return (
     <div>
-      <div>
-        {message && <Alert variant="success">{message}</Alert>}
-        <p>
-          <b>Verify your mobile to continue.</b>
-        </p>
-        <SingleInputForm
-          submitText="Send verification code"
-          placeholder="Please enter your mobile number"
-          onSubmit={sendSMS}
-          name="mobile"
-          validate={validateMobile}
-          style={{ display: hasSent ? "none" : undefined }}
-        />
-        <SingleInputForm
-          onSubmit={verifyCode}
-          placeholder="Please enter your 6-digit verification code"
-          submitText="Verify code"
-          name="code"
-          validate={validateCode}
-          style={{ display: hasSent ? undefined : "none" }}
-          renderActions={renderCodeActions}
-        />
-      </div>
-      <div className="mt-5 d-flex flex-row-reverse">
-        <Button variant="primary" onClick={skipKYC}>
-          Skip KYC
-        </Button>
-      </div>
+      {message && <Alert variant="success">{message}</Alert>}
+      <p>
+        <b>Verify your mobile to continue.</b>
+      </p>
+      <SingleInputForm
+        submitText="Send verification code"
+        placeholder="Please enter your mobile number"
+        onSubmit={sendSMS}
+        name="mobile"
+        validate={validateMobile}
+        style={{ display: hasSent ? "none" : undefined }}
+      />
+      <SingleInputForm
+        onSubmit={verifyCode}
+        placeholder="Please enter your 6-digit verification code"
+        submitText="Verify code"
+        name="code"
+        validate={validateCode}
+        style={{ display: hasSent ? undefined : "none" }}
+        renderActions={renderCodeActions}
+      />
     </div>
   );
 };

--- a/src/components/VerificationTracker/VerifyMobile.js
+++ b/src/components/VerificationTracker/VerifyMobile.js
@@ -9,7 +9,7 @@ import { AuthContext } from "components/auth/Auth";
 
 const VerifyEmail = () => {
   const [hasSent, setSent] = useState(false);
-  const { user } = useContext(AuthContext);
+  const { user, setVerified } = useContext(AuthContext);
   const [message, setMessage] = useState();
 
   const sendSMS = async (values, actions) => {
@@ -74,29 +74,39 @@ const VerifyEmail = () => {
     );
   };
 
+  const skipKYC = () => {
+    setVerified(true);
+  };
   return (
     <div>
-      {message && <Alert variant="success">{message}</Alert>}
-      <p>
-        <b>Verify your mobile to continue.</b>
-      </p>
-      <SingleInputForm
-        submitText="Send verification code"
-        placeholder="Please enter your mobile number"
-        onSubmit={sendSMS}
-        name="mobile"
-        validate={validateMobile}
-        style={{ display: hasSent ? "none" : undefined }}
-      />
-      <SingleInputForm
-        onSubmit={verifyCode}
-        placeholder="Please enter your 6-digit verification code"
-        submitText="Verify code"
-        name="code"
-        validate={validateCode}
-        style={{ display: hasSent ? undefined : "none" }}
-        renderActions={renderCodeActions}
-      />
+      <div>
+        {message && <Alert variant="success">{message}</Alert>}
+        <p>
+          <b>Verify your mobile to continue.</b>
+        </p>
+        <SingleInputForm
+          submitText="Send verification code"
+          placeholder="Please enter your mobile number"
+          onSubmit={sendSMS}
+          name="mobile"
+          validate={validateMobile}
+          style={{ display: hasSent ? "none" : undefined }}
+        />
+        <SingleInputForm
+          onSubmit={verifyCode}
+          placeholder="Please enter your 6-digit verification code"
+          submitText="Verify code"
+          name="code"
+          validate={validateCode}
+          style={{ display: hasSent ? undefined : "none" }}
+          renderActions={renderCodeActions}
+        />
+      </div>
+      <div className="mt-5 d-flex flex-row-reverse">
+        <Button variant="primary" onClick={skipKYC}>
+          Skip KYC
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/components/auth/Auth.js
+++ b/src/components/auth/Auth.js
@@ -11,6 +11,7 @@ export const AuthProvider = ({ children }) => {
   const [loginError, setLoginError] = useState(null);
   const [isVerified, setVerified] = useState(false);
   const [hasVerified, setHasVerified] = useState(false);
+  const [skipKYC, setSkipKYC] = useState(false);
 
   const { data: userDetails, error: fetchDetailsError } = useSWR(
     user && `/user/${user.id}`
@@ -95,7 +96,9 @@ export const AuthProvider = ({ children }) => {
         isVerified,
         setVerified,
         hasVerified,
-        setHasVerified
+        setHasVerified,
+        skipKYC,
+        setSkipKYC
       }}
     >
       {children}

--- a/src/pages/AddressesPage.js
+++ b/src/pages/AddressesPage.js
@@ -13,7 +13,7 @@ import useSelectedRow from "hooks/useSelectedRow";
 import "./Dashboard.scss";
 
 const AddressesPage = () => {
-  const { user } = useContext(AuthContext);
+  const { user, skipKYC } = useContext(AuthContext);
   const history = useHistory();
   const getAddressesUrl = `/user/${user.id}/address`;
   const [selected, setSelected, selectRowConfig] = useSelectedRow(null);
@@ -38,7 +38,8 @@ const AddressesPage = () => {
       icon: "add",
       title: "Add",
       onClick: () => history.push("/addresses/add"),
-      hide: hasMultipleAddresses
+      hide: hasMultipleAddresses,
+      disabled: skipKYC
     },
     {
       icon: "create-outline",


### PR DESCRIPTION
Allow user to skip KYC
To test,
1, start client site and signup as new user, finish email/phone valification and add payroll info
2. on the add address step. user can skip kyc by click  generate HD address button, but it's only one time thing,  it will still need KYC if user refesh the page or login again.
