### PR TITLE
Clarified functionality on BTC Threshold form

### DIFF
--- a/src/components/users/AccountInfoForm.js
+++ b/src/components/users/AccountInfoForm.js
@@ -7,23 +7,26 @@ import SubmitSpinnerButton from "components/forms/SubmitSpinnerButton";
 const AccountInfoForm = ({
   onSubmit,
   submitText = "Update Account Setting",
-  initialValues: _inititalValues
+  initialValues: _initialValues
 }) => {
   const initialValues = {
     btcThreshold: "",
-    ..._inititalValues
+    ..._initialValues
   };
 
   const validate = (values) => {
     const errors = {};
-    if (!values.btcThreshold)
+    if (values.btcThreshold.toString().length === 0)
       errors.btcThreshold = "Please enter a BTC Threshold";
-    if (!(Number(values.btcThreshold) > 0))
-      errors.btcThreshold = "BTC Threshold can not be 0";
-    if (Number(values.btcThreshold) > 1000)
-      errors.btcThreshold = "Maximun of BTC Threshold is 1000 ";
+    else if (!(values.btcThreshold >= 0))
+      errors.btcThreshold = "BTC Threshold cannot be less than $0.00";
+    if (values.btcThreshold > 1000)
+      errors.btcThreshold = "BTC Threshold must be at most $1000.00";
+    if (values.btcThreshold % 1 !== 0)
+      errors.btcThreshold = "BTC Threshold must be a whole dollar amount";
     return errors;
   };
+
   return (
     <Formik
       initialValues={initialValues}
@@ -33,7 +36,12 @@ const AccountInfoForm = ({
     >
       {({ isSubmitting, errors }) => (
         <Form className="deposit-form">
-          <Input label="BTC Threshold" name="btcThreshold" />
+          <Input
+            label="BTC Threshold Amount (AUD)"
+            name="btcThreshold"
+            type="number"
+            placeholder="$ AUD"
+          />
           <ErrorMessage error={errors.hidden} />
           <SubmitSpinnerButton
             submitText={submitText}


### PR DESCRIPTION
Changed the error messages to be more in line with the backend functionality. Made the input more resilient to bad inputs, as well as clarifying the fact that it is in aud. Not sure if the 400 error thrown by the server when decimals are given is a feature or bug, but either way I made decimals an invalid input.