### PR TITLE
GPIB-568

### DIFF
--- a/src/pages/AddressesPage.js
+++ b/src/pages/AddressesPage.js
@@ -59,14 +59,14 @@ const AddressesPage = () => {
       icon: "archive-outline",
       title: "Archive",
       onClick: () => history.push(`/addresses/archive/${selected}`),
-      disabled: !selected,
+      disabled: !selected || unGroupAddress?.length === 1,
       hide: !hasMultipleAddresses
     },
     {
       icon: "wallet-outline",
       title: "Group Address",
       onClick: () => history.push(`/addresses/group/${selected}`),
-      disabled: !selected || groupAddress.length > 0,
+      disabled: !selected || groupAddress.length === 2,
       hide: user?.idVerificationStatus !== 3 || !settings?.allowGroupedAddresses
     }
   ];


### PR DESCRIPTION
Small bug fix when doing GPIB-568
group address button: only when have two static addresses
archive address: not allow archive if only one static address.